### PR TITLE
Renames ignore->files, turns on strict mode for serde

### DIFF
--- a/docs/src/reference/files.md
+++ b/docs/src/reference/files.md
@@ -18,12 +18,9 @@ This section explains the options available for every files instance.
 # path to folder to select files to show
 path = "path/to/folder"
 
-# Add a glob to the set of overrides.
-#
-# Globs provided here have precisely the same semantics as a single line in a gitignore file,
-# where the meaning of `!` is inverted: namely, `!` at the beginning of a glob will ignore a
-# file. Without `!`, all matches of the glob provided are treated as whitelist matches.
-ignore = ["*.png", "!*.md"]
+# Override list for files. Files added here are included even if they are ignored,
+# prefixing entries with an exclamation mark turns them into ignores.
+files = ["*.png", "!*.md"]
 
 # When set, is the default file to show.
 default_file = "README.md"

--- a/docs/src/tests.md
+++ b/docs/src/tests.md
@@ -4,9 +4,9 @@ Source code of `mdbook-files`:
 
 ```files
 path = "."
+files = ["!.github", "!*.png", "!docs"]
 hidden = true
 git_ignore = true
-ignore = ["!.github", "!*.png", "!docs"]
 ```
 
 This is some paragraph after the thing.

--- a/docs/src/tests/book.md
+++ b/docs/src/tests/book.md
@@ -4,9 +4,9 @@ This is a subchapter.
 
 ```files
 path = "docs"
+files = ["!**/*.png"]
 hidden = true
 git_ignore = true
-ignore = ["!**/*.png"]
 default_file = "src/SUMMARY.md"
 ```
 

--- a/docs/src/tests/plugin.md
+++ b/docs/src/tests/plugin.md
@@ -4,9 +4,9 @@ Source code of `mdbook-files`:
 
 ```files
 path = "."
+files = ["!.github", "!*.png", "!docs"]
 hidden = true
 git_ignore = true
-ignore = ["!.github", "!*.png", "!docs"]
 ```
 
 This is some paragraph after the thing.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ use uuid::Uuid;
 
 /// Configuration for an invocation of files
 #[derive(Deserialize, Debug)]
+#[serde(deny_unknown_fields)]
 pub struct Files {
     /// Path to files
     pub path: Utf8PathBuf,
@@ -28,7 +29,7 @@ pub struct Files {
     /// where the meaning of `!` is inverted: namely, `!` at the beginning of a glob will ignore a
     /// file. Without `!`, all matches of the glob provided are treated as whitelist matches.
     #[serde(default)]
-    pub ignore: Vec<String>,
+    pub files: Vec<String>,
 
     /// When specified, path to the file that is opened by default.
     #[serde(default)]
@@ -194,7 +195,7 @@ impl<'a> Instance<'a> {
         let mut paths: FilesMap = Default::default();
         let parent = self.parent();
         let mut overrides = OverrideBuilder::new(&parent);
-        for item in &self.data.ignore {
+        for item in &self.data.files {
             overrides.add(item)?;
         }
         let overrides = overrides.build()?;


### PR DESCRIPTION
- Changes `ignore` field to be `files`
- When deserializing instances, we now treat unknown fields as errors